### PR TITLE
Fix commitlint CI

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+}

--- a/package.json
+++ b/package.json
@@ -36,11 +36,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
-  },
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"


### PR DESCRIPTION
The commitlint CI doesn't follow any rules yet. This is because the config for it was nested inside the `package.json` file. This works locally but fails for [Github action being used](https://github.com/wagoid/commitlint-github-action). This PR moves the config into a separate file.