### PR TITLE
Remove unnecessary files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
-/.idea/
-/src/
-/.tsconfig.json/
 /.github/
+/.idea/
+/.tsconfig.json/
+/commitlint.config.js
+/src/
+/test


### PR DESCRIPTION
Tests were included in the npm package as well as a few other files that shouldn't be. This PR adds them to the npm ignore.